### PR TITLE
DockerイメージをCUDA 12.9.1に更新し、requirements.txtでパッケージバージョンを固定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.3.2-cudnn9-runtime-ubuntu22.04
+FROM nvidia/cuda:12.9.1-cudnn-runtime-ubuntu22.04
 
 RUN apt-get update && apt-get install -y \
     python3 \
@@ -13,4 +13,5 @@ RUN useradd -m -s /bin/bash zen
 USER zen
 WORKDIR /home/zen
 
-RUN pip install faster-whisper
+COPY requirements.txt .
+RUN pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+faster-whisper==1.2.1
+anthropic==0.86.0


### PR DESCRIPTION
- ベースイメージを nvidia/cuda:12.3.2-cudnn9-runtime-ubuntu22.04 から nvidia/cuda:12.9.1-cudnn-runtime-ubuntu22.04 に更新
- requirements.txt を追加 (faster-whisper==1.2.1, anthropic==0.86.0)
- Dockerfile を requirements.txt 参照に変更

Closes #3