### PR TITLE
VADパラメータを調整しハルシネーションを防止

### DIFF
--- a/main.py
+++ b/main.py
@@ -48,9 +48,14 @@ japanese_parameters = {
     "beam_size": 10,                   # 候補を多く探索（精度重視）
     "best_of": 1,
     "temperature": 0.0,
-    "vad_filter": True,                # 無音スキップ
-    "without_timestamps": True,        # タイムスタンプ無し
-    "condition_on_previous_text": True, # 前文脈を引き継ぎ一貫性UP
+    "vad_filter": True,                # 無音スキップ（ハルシネーション防止のため有効化）
+    "vad_parameters": {
+        "threshold": 0.1,              # 音声検出の閾値を大幅に下げる
+        "min_speech_duration_ms": 50,
+        "min_silence_duration_ms": 2000,
+    },
+    "without_timestamps": False,       # タイムスタンプ有効化
+    "condition_on_previous_text": False, # Trueにすると同一フレーズが連鎖するリスクがある
     "suppress_blank": True,            # 空白抑制
     "initial_prompt": "以下は日本語の住宅に関する打ち合わせや説明の音声です。正確に文字起こししてください。句読点（、。）を適切に使用してください。",
 }

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from faster_whisper import WhisperModel
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Transcribe audio file using Faster Whisper')
-    parser.add_argument('input_file', help='Input audio filename (e.g., audio.mp3). Assumed to be in the "inputs" directory.')
+    parser.add_argument('input_file', nargs='+', help='Input audio filenames (e.g., audio1.mp3 audio2.mp3). Assumed to be in the "inputs" directory.')
     return parser.parse_args()
 
 model_size = "large-v3"
@@ -63,34 +63,37 @@ args = parse_args()
 
 # Construct the full path to the input file in the 'inputs' directory
 input_dir = "inputs"
-full_input_file_path = os.path.join(input_dir, args.input_file)
 
-segments, info = model.transcribe(
-    full_input_file_path, 
-    **parameters,
-)
-
-print("Detected language '%s' with probability %f" % (info.language, info.language_probability))
-
-# 入力ファイル名から出力ファイル名を生成
-input_filename = args.input_file
 output_dir = "outputs"
-output_filename = os.path.join(output_dir, f"{input_filename.rsplit('.', 1)[0]}_transcript.txt")
 
-# 全セグメントのテキストを準備
-output_text = [f"Detected language: {info.language} (probability: {info.language_probability:.2f})\n\n"]
+for input_file in args.input_file:
+    full_input_file_path = os.path.join(input_dir, input_file)
 
-for segment in segments:
-    start_time = f"{int(segment.start // 60):02d}:{int(segment.start % 60):02d}"
-    end_time = f"{int(segment.end // 60):02d}:{int(segment.end % 60):02d}"
-    line = f"[{start_time} -> {end_time}] {segment.text}"
-    
-    # コンソールに出力
-    print(line)
-    
-    # 出力テキストに追加
-    output_text.append(line)
+    segments, info = model.transcribe(
+        full_input_file_path, 
+        **parameters,
+    )
 
-# 全てのテキストを一度にファイルに書き込み
-with open(output_filename, "w", encoding="utf-8") as f:
-    f.write("\n".join(output_text))
+    print(f"Detected language '{info.language}' with probability {info.language_probability}")
+
+    # 入力ファイル名から出力ファイル名を生成
+    input_filename = input_file
+    output_filename = os.path.join(output_dir, f"{input_filename.rsplit('.', 1)[0]}_transcript.txt")
+
+    # 全セグメントのテキストを準備
+    output_text = [f"Detected language: {info.language} (probability: {info.language_probability:.2f})\n\n"]
+
+    for segment in segments:
+        start_time = f"{int(segment.start // 60):02d}:{int(segment.start % 60):02d}"
+        end_time = f"{int(segment.end // 60):02d}:{int(segment.end % 60):02d}"
+        line = f"[{start_time} -> {end_time}] {segment.text}"
+        
+        # コンソールに出力
+        print(line)
+        
+        # 出力テキストに追加
+        output_text.append(line)
+
+    # 全てのテキストを一度にファイルに書き込み
+    with open(output_filename, "w", encoding="utf-8") as f:
+        f.write("\n".join(output_text))


### PR DESCRIPTION
## Summary
- VADフィルターの閾値を0.1に下げ、音声が誤って除外される問題を解消
- VADパラメータ（min_speech_duration_ms, min_silence_duration_ms）を明示的に設定
- `condition_on_previous_text: False` で「はい。」「ご視聴ありがとうございました」等の同一フレーズ連鎖ハルシネーションを防止
- タイムスタンプを有効化し、セグメント精度を向上

## Test plan
- [x] m4aファイルで文字起こしが正常に動作することを確認済み
- [x] 「はい。」の連鎖ハルシネーションが解消されることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)